### PR TITLE
fix null results

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/smart-rpc",
-  "version": "1.0.18",
+  "version": "1.0.19",
   "description": "Intelligent transport layer for Solana RPCs.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/transport-manager.ts
+++ b/src/transport-manager.ts
@@ -318,7 +318,9 @@ export class TransportManager {
         statusCode: 200,
       });
 
-      result.SmartRpcProvider = transport.transportConfig.id;
+      if(typeof result === 'object' && !!result) {
+        result.SmartRpcProvider = transport.transportConfig.id;
+      }
 
       return result;
     } catch (error: any) {


### PR DESCRIPTION
fixes `Final attempt with transport failed: TypeError: Cannot set properties of null (setting 'SmartRpcProvider')`

this is blocking the magic eden pipeline