### PR TITLE
add flag to skip last resort sends

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/smart-rpc",
-  "version": "1.0.19",
+  "version": "1.1.0",
   "description": "Intelligent transport layer for Solana RPCs.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Triton's rate limit for getBlock is pretty strict, and we'll quickly get into a death spiral if we ignore their 429s. We can keep the existing behavior by default, but I'm planning to skip this for block ingestor.