### PR TITLE
throw original error to help debug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/smart-rpc",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "description": "Intelligent transport layer for Solana RPCs.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",

--- a/src/transport-manager.ts
+++ b/src/transport-manager.ts
@@ -419,6 +419,7 @@ export class TransportManager {
   // It includes a retry mechanism with exponential backoff for handling HTTP 429 (Too Many Requests) errors.
   async smartTransport(methodName, ...args): Promise<any[]> {
     let availableTransports = this.availableTransportsForMethod(methodName);
+    let recentError: any = null;
 
     while (availableTransports.length > 0) {
       const transport = this.selectTransport(availableTransports);
@@ -443,6 +444,7 @@ export class TransportManager {
         if (!transport.transportConfig.enableFailover) {
           throw e;
         }
+        recentError = e
       }
 
       // Remove a transport with exceeded rate limit and retry with the next available one
@@ -464,6 +466,9 @@ export class TransportManager {
     }
 
     // Throw error if all available transports have been tried without success
-    throw new Error("No available transports for the requested method.");
+    let error = 
+      recentError ??
+      new Error("No available transports for the requested method.")
+    throw recentError;
   }
 }


### PR DESCRIPTION
A user is unable to make a transaction because of an RPC error. Try to preserve the original error to help debugging

<img width="820" alt="Screenshot 2024-05-02 at 11 17 40 PM" src="https://github.com/tensor-hq/smart-rpc/assets/135168569/bdaef0dc-2a22-428b-8a66-207e2c3749eb">

https://discord.com/channels/953488546608599071/1235490051073507389