### PR TITLE
remove async function constraint

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@tensor-hq/smart-rpc",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "description": "Intelligent transport layer for Solana RPCs.",
   "sideEffects": false,
   "module": "./dist/esm/index.js",


### PR DESCRIPTION
Method constructors in react native appear to strip the AsyncFunction naming, as opposed to web. We should be able to remove that AsyncFunction check since it appears only subscription-related methods are non-async, and we don't use those with smart rpc anyways.






